### PR TITLE
Add .NET SDK for ONNX inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,8 @@ dmypy.json
 # Pyre type checker
 .pyre/
 onnx_models/mit_b2.onnx
+
+# .NET build artifacts
+**/bin/
+**/obj/
+TruFor.Sdk/models/

--- a/README.md
+++ b/README.md
@@ -109,6 +109,62 @@ Running on all 50 images yields the following average absolute errors:
 | Noiseprint++ | 2.63 × 10⁻⁵ |
 | mit_b2       | 3.74 |
 
+## TruFor.Sdk (.NET 9)
+
+The repository includes a simple .NET 9 SDK that performs inference with
+the ONNX models using [SkiaSharp](https://github.com/mono/SkiaSharp) for
+image loading and [OnnxRuntime](https://onnxruntime.ai/) for model
+execution.
+
+Install the required .NET version using the provided script:
+
+```bash
+chmod +x dotnet-install.sh
+./dotnet-install.sh -c 9.0
+```
+
+Copy the ONNX models into `TruFor.Sdk/models` so they are available at
+runtime:
+
+```bash
+mkdir -p TruFor.Sdk/models
+cp onnx_models/noiseprint_pp.onnx TruFor.Sdk/models/
+./onnx_chunk.sh merge onnx_models/mit_b2 TruFor.Sdk/models/mit_b2.onnx
+```
+
+The SDK looks for these files in its `models` directory and does not
+perform any merging at runtime.
+
+Build the SDK and the sample console application:
+
+```bash
+~/.dotnet/dotnet build TruFor.Sdk/TruFor.Sdk.csproj
+~/.dotnet/dotnet build TruFor.Sdk.Sample/TruFor.Sdk.Sample.csproj
+```
+
+Run inference on an image; the sample app writes intermediate results as
+JSON files:
+
+```bash
+~/.dotnet/dotnet run --project TruFor.Sdk.Sample/TruFor.Sdk.Sample.csproj \
+    sample_dataset/real/airplane_139871.png dotnet_out
+```
+
+### Comparison with PyTorch and ONNX
+
+For the image above we compared the outputs of the SDK with the original
+PyTorch models and with ONNXRuntime (Python). The mean absolute error
+(MAE) shows that the .NET implementation matches the ONNX results while
+deviating from the PyTorch outputs by the same amount:
+
+| Output | .NET vs PyTorch MAE | .NET vs ONNX MAE |
+|-------|--------------------:|-----------------:|
+| Noiseprint | 2.53 × 10⁻⁵ | 0 |
+| Seg0 | 3.89 | 7.4 × 10⁻⁴ |
+| Seg1 | 3.49 | 4.4 × 10⁻⁴ |
+| Seg2 | 3.77 | 2.9 × 10⁻⁴ |
+| Seg3 | 3.75 | 2.4 × 10⁻⁴ |
+
 ## ONNX split/merge
 
 The helper script `onnx_chunk.sh` splits a large ONNX file into smaller

--- a/TruFor.Sdk.Sample/Program.cs
+++ b/TruFor.Sdk.Sample/Program.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using SkiaSharp;
+using TruFor.Sdk;
+
+if (args.Length < 2)
+{
+    Console.WriteLine("Usage: TruFor.Sdk.Sample <imagePath> <outputDir>");
+    return;
+}
+
+var imagePath = args[0];
+var outputDir = args[1];
+Directory.CreateDirectory(outputDir);
+
+using var bitmap = SKBitmap.Decode(imagePath);
+using var sdk = new TruForSdk();
+
+var np = sdk.RunNoiseprint(bitmap);
+File.WriteAllText(Path.Combine(outputDir, "noiseprint.json"), TensorToJson(np));
+
+var segs = sdk.RunSegmentation(bitmap);
+for (int i = 0; i < segs.Count; i++)
+{
+    File.WriteAllText(Path.Combine(outputDir, $"seg_{i}.json"), TensorToJson(segs[i]));
+}
+
+static string TensorToJson(DenseTensor<float> t)
+{
+    var obj = new { shape = t.Dimensions.ToArray(), data = t.Buffer.ToArray() };
+    return JsonSerializer.Serialize(obj);
+}

--- a/TruFor.Sdk.Sample/TruFor.Sdk.Sample.csproj
+++ b/TruFor.Sdk.Sample/TruFor.Sdk.Sample.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\TruFor.Sdk\TruFor.Sdk.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/TruFor.Sdk/TruFor.Sdk.csproj
+++ b/TruFor.Sdk/TruFor.Sdk.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.18.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="models/*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/TruFor.Sdk/TruForSdk.cs
+++ b/TruFor.Sdk/TruForSdk.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using SkiaSharp;
+
+namespace TruFor.Sdk;
+
+public sealed class TruForSdk : IDisposable
+{
+    private readonly InferenceSession _noiseprint;
+    private readonly InferenceSession _mit;
+
+    public TruForSdk(string? modelsDirectory = null)
+    {
+        modelsDirectory ??= Path.Combine(AppContext.BaseDirectory, "models");
+
+        if (!Directory.Exists(modelsDirectory))
+            throw new DirectoryNotFoundException(modelsDirectory);
+
+        var noiseprintPath = Path.Combine(modelsDirectory, "noiseprint_pp.onnx");
+        if (!File.Exists(noiseprintPath))
+            throw new FileNotFoundException(noiseprintPath);
+        _noiseprint = new InferenceSession(noiseprintPath);
+
+        var mitPath = Path.Combine(modelsDirectory, "mit_b2.onnx");
+        if (!File.Exists(mitPath))
+            throw new FileNotFoundException(mitPath);
+        _mit = new InferenceSession(mitPath);
+    }
+
+    private static DenseTensor<float> BitmapToTensor(SKBitmap bmp)
+    {
+        var tensor = new DenseTensor<float>(new[] { 1, 3, bmp.Height, bmp.Width });
+        for (int y = 0; y < bmp.Height; y++)
+        {
+            for (int x = 0; x < bmp.Width; x++)
+            {
+                var c = bmp.GetPixel(x, y);
+                tensor[0, 0, y, x] = c.Red / 255f;
+                tensor[0, 1, y, x] = c.Green / 255f;
+                tensor[0, 2, y, x] = c.Blue / 255f;
+            }
+        }
+        return tensor;
+    }
+
+    public DenseTensor<float> RunNoiseprint(SKBitmap bitmap)
+    {
+        var input = BitmapToTensor(bitmap);
+        var inputs = new[] { NamedOnnxValue.CreateFromTensor("image", input) };
+        using var results = _noiseprint.Run(inputs);
+        return (DenseTensor<float>)results.First().Value;
+    }
+
+    public IReadOnlyList<DenseTensor<float>> RunSegmentation(SKBitmap bitmap)
+    {
+        var rgb = BitmapToTensor(bitmap);
+        var np = RunNoiseprint(bitmap);
+        var np3 = new DenseTensor<float>(new[] { 1, 3, bitmap.Height, bitmap.Width });
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                float v = np[0, 0, y, x];
+                np3[0, 0, y, x] = v;
+                np3[0, 1, y, x] = v;
+                np3[0, 2, y, x] = v;
+            }
+        }
+
+        var inputs = new[]
+        {
+            NamedOnnxValue.CreateFromTensor("rgb", rgb),
+            NamedOnnxValue.CreateFromTensor("np", np3)
+        };
+        using var results = _mit.Run(inputs);
+        return results.Select(r => (DenseTensor<float>)r.Value).ToList();
+    }
+
+    public void Dispose()
+    {
+        _noiseprint.Dispose();
+        _mit.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- load ONNX models from SDK `models` directory and drop runtime merge logic
- update sample console to use default model path and document setup in README
- ensure SDK project copies `models` folder and ignore it in git

## Testing
- `~/.dotnet/dotnet build TruFor.Sdk/TruFor.Sdk.csproj`
- `~/.dotnet/dotnet build TruFor.Sdk.Sample/TruFor.Sdk.Sample.csproj`
- `~/.dotnet/dotnet run --project TruFor.Sdk.Sample/TruFor.Sdk.Sample.csproj sample_dataset/real/airplane_139871.png dotnet_out`
- `PYTHONPATH=. python - <<'PY'
import json, numpy as np, torch, onnxruntime as ort
from scripts.test_onnx_models import load_image, build_noiseprint_model, build_mit_b2_model

img_path = 'sample_dataset/real/airplane_139871.png'
img = load_image(img_path)

np_model = build_noiseprint_model()
seg_model = build_mit_b2_model()

with torch.no_grad():
    np_torch = np_model(img).numpy()
    np_rgb = np.repeat(np_torch, 3, axis=1)
    seg_torch = seg_model(img, torch.from_numpy(np_rgb))
    seg_torch = [s.detach().numpy() for s in seg_torch]

ort_np = ort.InferenceSession('onnx_models/noiseprint_pp.onnx')
ort_seg = ort.InferenceSession('TruFor.Sdk/models/mit_b2.onnx')
np_onnx = ort_np.run(None, {'image': img.numpy()})[0]
np_rgb_onnx = np.repeat(np_torch, 3, axis=1)
seg_onnx = ort_seg.run(None, {'rgb': img.numpy(), 'np': np_rgb_onnx})

def load_json(path):
    with open(path) as f:
        j = json.load(f)
    return np.array(j['data'], dtype=np.float32).reshape(j['shape'])

np_dotnet = load_json('dotnet_out/noiseprint.json')
seg_dotnet = [load_json(f'dotnet_out/seg_{i}.json') for i in range(len(seg_onnx))]

def mae(a,b):
    return np.mean(np.abs(a-b))

print('Noiseprint .NET vs PyTorch', mae(np_dotnet, np_torch))
print('Noiseprint .NET vs ONNX', mae(np_dotnet, np_onnx))
print('Noiseprint ONNX vs PyTorch', mae(np_onnx, np_torch))
for i,(t,o,d) in enumerate(zip(seg_torch, seg_onnx, seg_dotnet)):
    print(f'Seg{i} .NET vs PyTorch', mae(d,t))
    print(f'Seg{i} .NET vs ONNX', mae(d,o))
    print(f'Seg{i} ONNX vs PyTorch', mae(o,t))
PY`


------
https://chatgpt.com/codex/tasks/task_e_688f55d28cd08325a87a98d9b1b523d5